### PR TITLE
Adding mountpath for express sub apps

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 const prometheus = require('prom-client');
 const onFinished = require('on-finished');
+const path = require('path');
 
 class Middleware {
 
@@ -93,7 +94,7 @@ class Middleware {
         }
 
         if (labels.hasOwnProperty('route')) {
-          labels['route'] = req.route ? req.route.path : null;
+          labels['route'] = req.route ? path.join(req.app.mountpath, req.route.path) : null;
         }
 
         timeRequest();


### PR DESCRIPTION
express route.path doesn't include the mount path when an app is mounted onto another app. e.g.

``` js
rootApp.use('/mount', subApp)
```

According to the docs

> The app.mountpath property contains one or more path patterns on which a sub-app was mounted.

However I've only managed to get it to return a single mountpath in testing. This solution doesn't work when mounting a router instead of an app.
